### PR TITLE
Allowing default gutters setting to be overwritten

### DIFF
--- a/src/_config.scss
+++ b/src/_config.scss
@@ -1,3 +1,4 @@
+$d2l-vui-grid-system-gutters: 30/70 !default;
 
 $susy: (
 	flow: ltr,
@@ -8,7 +9,7 @@ $susy: (
 	container-position: center,
 	last-flow: to,
 	columns: 12,
-	gutters: 30/70,
+	gutters: $d2l-vui-grid-system-gutters,
 	gutter-position: after,
 	global-box-sizing: border-box,
 	debug: (


### PR DESCRIPTION
@dlockhart I needed to be able to set the gutters setting in susy for the homepages margin change.  Because of how susy works and sass in general, this seemed like the easiest way to allow that one particular setting to be overwritten.